### PR TITLE
feat(hook): add zm_conf_path to locate zm.conf for DB tagging

### DIFF
--- a/docs/guides/config.rst
+++ b/docs/guides/config.rst
@@ -544,6 +544,9 @@ Consumed by ``zm_detect.py`` / ``utils.py``:
    * - ``tag_detected_objects``
      - ``no``
      - Write detected labels as ZM Tags (requires ZM >= 1.37.44)
+   * - ``zm_conf_path``
+     - *none* (pyzm auto-discovers)
+     - Directory holding ZoneMinder's ``zm.conf`` (and ``conf.d/*.conf``), used by ``tag_detected_objects`` for DB access. pyzm auto-discovers common locations (``/etc/zm``, ``/config``, ``/etc/zoneminder``), so most installs — including containers using ``/config`` — need nothing here. Set this only to force a non-standard path
    * - ``poly_color``
      - ``(255,255,255)``
      - RGB color for polygon overlays on annotated images

--- a/hook/objectconfig.example.yml
+++ b/hook/objectconfig.example.yml
@@ -10,11 +10,17 @@
 # general.base_data_path wherever it appears.
 
 general:
-  # Override pyzm settings (e.g. database host, debug level).
-  # If ZM uses a UNIX socket (ZM_DB_HOST=localhost:/var/run/mysqld/mysqld.sock),
-  # set dbhost: "localhost:3306" here.
+  # Override pyzm settings (e.g. debug level).
   pyzm_overrides:
     log_level_debug: 5
+
+  # Directory holding ZoneMinder's zm.conf (and conf.d/*.conf). Only needed
+  # by the ZM Tags feature (tag_detected_objects), which reads ZM's DB
+  # credentials from these files. pyzm auto-discovers common locations
+  # (/etc/zm, /config, /etc/zoneminder), so most installs — including
+  # containers using /config — need nothing here. Set this only to force a
+  # non-standard path.
+  #zm_conf_path: /some/custom/path
 
   # Secrets file for credential tokens (!TOKEN_NAME syntax)
   secrets: /etc/zm/secrets.yml

--- a/hook/tests/test_config_flow.py
+++ b/hook/tests/test_config_flow.py
@@ -483,3 +483,41 @@ class TestConfigVariantCombinations:
         assert push["use_fcm"] == "yes"
         assert push["fcm_tokens"] == ["token_a", "token_b"]
         assert push["channels"]["default"]["title"] == "Alert"
+
+
+# ===========================================================================
+# 6. TestZmConfPath
+# ===========================================================================
+
+class TestZmConfPath:
+    """Test that zm_conf_path is recognized and flows into g.config.
+
+    zm_detect.py passes g.config['zm_conf_path'] to ZMClient(conf_path=...),
+    which pyzmNg uses to locate zm.conf for DB-based tagging. See issue #32.
+    """
+
+    def test_zm_conf_path_recognized(self, tmp_path, ctx):
+        """A zm_conf_path under general is stored in g.config."""
+        cfg = {
+            "general": _minimal_general(zm_conf_path="/config"),
+            "ml": {
+                "ml_sequence": {"general": {"model_sequence": "object"}},
+                "stream_sequence": {"resize": 800},
+            },
+        }
+        cfg_path = _make_config_file(tmp_path, cfg)
+        process_config({"config": cfg_path}, ctx)
+        assert g.config["zm_conf_path"] == "/config"
+
+    def test_zm_conf_path_defaults_to_none(self, tmp_path, ctx):
+        """When unset, zm_conf_path defaults to None so pyzm uses its default."""
+        cfg = {
+            "general": _minimal_general(),
+            "ml": {
+                "ml_sequence": {"general": {"model_sequence": "object"}},
+                "stream_sequence": {"resize": 800},
+            },
+        }
+        cfg_path = _make_config_file(tmp_path, cfg)
+        process_config({"config": cfg_path}, ctx)
+        assert g.config["zm_conf_path"] is None

--- a/hook/zm_detect.py
+++ b/hook/zm_detect.py
@@ -93,7 +93,8 @@ def main_handler():
 
     # Connect to ZM via pyzm v2
     zm = ZMClient(api_url=g.config['api_portal'], user=g.config['user'], password=g.config['password'],
-                  portal_url=g.config['portal'], verify_ssl=(g.config['allow_self_signed'] != 'yes'))
+                  portal_url=g.config['portal'], verify_ssl=(g.config['allow_self_signed'] != 'yes'),
+                  conf_path=g.config.get('zm_conf_path'))
 
     # Import ZM zones via pyzm client (ref: ZoneMinder/zmeventnotificationNg#18)
     if g.config.get('import_zm_zones') == 'yes':

--- a/hook/zmes_hook_helpers/common_params.py
+++ b/hook/zmes_hook_helpers/common_params.py
@@ -24,6 +24,11 @@ config_vals = {
             'type': 'dict',
 
         },
+        'zm_conf_path': {
+            'section': 'general',
+            'default': None,
+            'type': 'string'
+        },
         'portal':{
             'section': 'general',
             'default': '',


### PR DESCRIPTION
## Summary

The `tag_detected_objects` feature opens a direct MySQL connection via pyzmNg's `get_zm_db()`, which reads ZoneMinder's `zm.conf`. There was no way to point the hook at that file from `objectconfig.yml`, so containerized ZM installs (where `zm.conf` lives at `/config`) silently fell back to `host=localhost` and tagging failed with a connection error. A stray `dbhost:` under `general` was reported as unrecognized, which misled users.

Detection, notes, and image write are unaffected (they go over the API); only DB-based **tagging** was broken.

## Change

- Add a `zm_conf_path` key (general section) and pass it to `ZMClient(conf_path=...)`. pyzmNg already honors `conf_path` end to end, so no code change is needed there.
- Fix the misleading `dbhost` comment in `objectconfig.example.yml` (that key under `pyzm_overrides` only affects pyzm's *logging* DB, not the tagging DB).
- Document the new key in the config reference.

## Tests

`TestZmConfPath` (key recognized + defaults to `None`); full non-e2e hook suite: **104 passed**.

Fixes #32. Pairs with ZoneMinder/pyzmNg#55, which adds auto-discovery of `/config` / `/etc/zoneminder` so most installs need no config at all — `zm_conf_path` then becomes an explicit override for non-standard paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)