### PR TITLE
test: local pre-push gate + real-pyzm contract test + model-require

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,17 @@
+#!/bin/sh
+# ES pre-push gate. Blocks a push when the Tier-1 suite is red.
+# Install once with: make hooks   (sets core.hooksPath -> .githooks)
+#
+# Tier-1: perl (prove) + hook unit tests + tools. The full real-pyzm e2e
+# gate is `make release-gate`, run before a release on a box with models.
+#
+# Escape hatch for a genuine emergency: git push --no-verify
+
+echo "pre-push: running Tier-1 test gate (make gate)..."
+if ! make gate; then
+	echo
+	echo "pre-push: BLOCKED -- Tier-1 tests failed. Fix them, or push with --no-verify to override."
+	exit 1
+fi
+echo "pre-push: gate green."
+exit 0

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,7 +41,19 @@ this repo; `CLAUDE.md` just points here.
 
 ## Verification (the test gate)
 
-Run all three tiers before committing. All must pass.
+Install the pre-push hook once per clone: `make hooks`. It runs `make gate`
+on `git push` and blocks a red push (`--no-verify` overrides an emergency).
+
+- `make gate` — Tier-1: perl + hook (not e2e) + tools. This is the per-push gate.
+- `make release-gate` — Tier-1 + real-pyzm e2e with `ZM_E2E_REQUIRE=1` (a missing
+  model or unimportable pyzm FAILS instead of skipping). Run before a release.
+
+The gate puts the pyzm checkout (`PYZM_SRC`, default `~/fiddle/pyzmNg`) on
+`PYTHONPATH` so `hook/tests/test_pyzm_contract.py` imports the REAL pyzm and
+catches cross-repo drift (a renamed `DetectionResult` key, a changed
+`detect_event` signature) on every push.
+
+The raw commands the Makefile runs, if you need them directly:
 
 ```bash
 # Perl (Event Server: zmeventnotification.pl + ZmEventNotification/*.pm)

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,45 @@
+# zmeventnotification (ES) developer test gate.
+#
+# Run `make hooks` once after cloning to install the pre-push gate.
+# `make gate`         -> Tier-1: perl + hook (not e2e) + tools. No models/ZM.
+# `make release-gate` -> Tier-1 + real e2e (models + real pyzm), require mode.
+#
+# ES's hook code leans on the pyzm library, which is a source checkout (not
+# pip-installed). PYZM_SRC points the gate at it so the pyzm<->ES contract
+# test can import the REAL pyzm. Override if your checkout is elsewhere:
+#   make gate PYZM_SRC=/path/to/pyzmNg
+
+PY ?= python3
+PYZM_SRC ?= $(HOME)/fiddle/pyzmNg
+
+.PHONY: gate release-gate perl hook tools e2e hooks help
+
+help:
+	@echo "make gate          - pre-push gate (perl + hook + tools)"
+	@echo "make release-gate  - full gate incl. real-pyzm e2e (needs models)"
+	@echo "make hooks         - install the git pre-push hook (run once)"
+
+# The pre-push gate. PYZM_SRC on PYTHONPATH lets the pyzm<->ES contract test
+# import real pyzm and catch cross-repo drift on every push; the rest of the
+# hook suite still runs against the stub in tests/conftest.py.
+gate: perl hook tools
+
+perl:
+	prove -I t/lib -I . -r t/
+
+hook:
+	cd hook && PYTHONPATH=$(PYZM_SRC) $(PY) -m pytest tests/ -m "not e2e" -q
+
+tools:
+	$(PY) -m pytest tools/tests/ -q
+
+# Pre-release: real e2e with real pyzm + models. ZM_E2E_REQUIRE=1 turns a
+# missing prerequisite (models, real pyzm) into a FAILURE, not a silent skip.
+release-gate: gate e2e
+
+e2e:
+	cd hook && PYTHONPATH=$(PYZM_SRC) ZM_E2E_REQUIRE=1 $(PY) -m pytest tests/test_e2e/ -q
+
+hooks:
+	git config core.hooksPath .githooks
+	@echo "pre-push gate installed (core.hooksPath -> .githooks)"

--- a/hook/tests/test_e2e/conftest.py
+++ b/hook/tests/test_e2e/conftest.py
@@ -82,6 +82,11 @@ def _collect_prereq_reasons() -> list[str]:
     reasons = []
     if not os.path.isdir(MODELS_DIR):
         reasons.append(f"model dir {MODELS_DIR} not found")
+    elif _discover_model() is None:
+        # Dir exists but holds no usable YOLO model -- otherwise every e2e
+        # test would skip green from inside find_one_model_path(), defeating
+        # ZM_E2E_REQUIRE=1.
+        reasons.append(f"no usable YOLO model in {MODELS_DIR}")
     if not os.path.isfile(BIRD_IMAGE):
         reasons.append(f"test image {BIRD_IMAGE} not found")
     if not _real_pyzm_importable():
@@ -276,12 +281,27 @@ def run_detect_chain(
 
 
 def find_one_model_path() -> tuple[str, str, str]:
-    """Find one available YOLO model.
+    """Find one available YOLO model, or skip if none exists.
 
     Returns (weights_path, config_path, labels_path).
     config_path is "" for ONNX models (no config needed).
     """
+    found = _discover_model()
+    if found is None:
+        pytest.skip("No YOLO model found in " + str(MODELS_DIR))
+    return found
+
+
+def _discover_model() -> tuple[str, str, str] | None:
+    """Discover one usable YOLO model without skipping. Returns None if none.
+
+    Shared by find_one_model_path() and the prereq gate so that a missing
+    model is caught as a prerequisite (hard-failing under ZM_E2E_REQUIRE=1)
+    instead of skipping green from inside a test.
+    """
     models_dir = Path(MODELS_DIR)
+    if not models_dir.is_dir():
+        return None
 
     # First, build a labels lookup (some dirs have labels, others don't)
     all_labels: str | None = None
@@ -325,7 +345,7 @@ def find_one_model_path() -> tuple[str, str, str]:
             if config:
                 return weights, config, labels
 
-    pytest.skip("No YOLO model found in " + str(models_dir))
+    return None
 
 
 def basic_ml_sequence(

--- a/hook/tests/test_pyzm_contract.py
+++ b/hook/tests/test_pyzm_contract.py
@@ -1,0 +1,124 @@
+"""Contract test between ES and the REAL pyzm library.
+
+Every other hook unit test runs against the fake ``pyzm`` stub that
+``tests/conftest.py`` injects into ``sys.modules``. That stub is whatever we
+hand-typed -- nothing ties it to the real pyzm at ~/fiddle/pyzmNg. So a real
+pyzm change (a renamed ``DetectionResult`` key, a changed ``detect_event``
+signature) is invisible to the unit suite and blows up only in production.
+
+This test strips the stub, imports the REAL pyzm, and asserts the exact shape
+ES consumes. It runs whenever real pyzm is importable (the gate sets
+``PYTHONPATH`` to the pyzm checkout). When pyzm cannot be imported it skips by
+default and FAILS under ``ZM_E2E_REQUIRE=1`` (the release gate), so drift can
+never merge silently.
+
+Keys/signatures asserted here are derived from the real ES call sites:
+  - hook/zmes_hook_helpers/utils.py + hook/zm_detect.py read these dict keys.
+  - hook/zm_detect.py calls detect_event(zm, id, zones=, stream_config=) and
+    detect(input, zones=).
+"""
+
+from __future__ import annotations
+
+import inspect
+import os
+import sys
+
+import pytest
+
+# Keys ES reads by name from DetectionResult.to_dict() / matched_data.
+# A missing key here is a production KeyError in format_detection_output.
+ES_CONSUMED_KEYS = {
+    "boxes",
+    "confidences",
+    "labels",
+    "model_names",
+    "frame_id",
+    "image",
+    "image_dimensions",
+    "polygons",
+}
+
+
+def _import_real_pyzm():
+    """Import real pyzm with the unit-test stub stripped. Returns the module
+    or None if the genuine package is not importable."""
+    import importlib
+
+    saved = {k: v for k, v in list(sys.modules.items())
+             if k == "pyzm" or k.startswith("pyzm.")}
+    for k in saved:
+        del sys.modules[k]
+    try:
+        return importlib.import_module("pyzm")
+    except Exception:
+        return None
+    finally:
+        for k in [k for k in sys.modules if k == "pyzm" or k.startswith("pyzm.")]:
+            del sys.modules[k]
+        sys.modules.update(saved)
+
+
+def _real_pyzm_or_skip():
+    mod = _import_real_pyzm()
+    if mod is not None:
+        return
+    msg = ("real pyzm not importable (set PYTHONPATH to the pyzm checkout, "
+           "e.g. make gate)")
+    if os.environ.get("ZM_E2E_REQUIRE") == "1":
+        pytest.fail(msg, pytrace=False)
+    pytest.skip(msg)
+
+
+def test_detectionresult_to_dict_has_keys_es_consumes():
+    """Real DetectionResult.to_dict() must contain every key ES reads."""
+    _real_pyzm_or_skip()
+    import importlib
+
+    saved = {k: v for k, v in list(sys.modules.items())
+             if k == "pyzm" or k.startswith("pyzm.")}
+    for k in saved:
+        del sys.modules[k]
+    try:
+        det_mod = importlib.import_module("pyzm.models.detection")
+        BBox, Detection, DetectionResult = det_mod.BBox, det_mod.Detection, det_mod.DetectionResult
+        result = DetectionResult(
+            detections=[Detection("person", 0.9, BBox(0, 0, 10, 10), model_name="yolov4")],
+            frame_id="snapshot",
+        )
+        keys = set(result.to_dict().keys())
+    finally:
+        for k in [k for k in sys.modules if k == "pyzm" or k.startswith("pyzm.")]:
+            del sys.modules[k]
+        sys.modules.update(saved)
+
+    missing = ES_CONSUMED_KEYS - keys
+    assert not missing, (
+        f"pyzm DetectionResult.to_dict() no longer emits keys ES consumes: "
+        f"{missing}. ES format_detection_output would KeyError in production."
+    )
+
+
+def test_detect_event_signature_matches_es_call():
+    """Real Detector.detect_event must accept the args zm_detect.py passes:
+    detect_event(zm, event_id, zones=..., stream_config=...)."""
+    _real_pyzm_or_skip()
+    import importlib
+
+    saved = {k: v for k, v in list(sys.modules.items())
+             if k == "pyzm" or k.startswith("pyzm.")}
+    for k in saved:
+        del sys.modules[k]
+    try:
+        detector_mod = importlib.import_module("pyzm.ml.detector")
+        params = inspect.signature(detector_mod.Detector.detect_event).parameters
+    finally:
+        for k in [k for k in sys.modules if k == "pyzm" or k.startswith("pyzm.")]:
+            del sys.modules[k]
+        sys.modules.update(saved)
+
+    for needed in ("zones", "stream_config"):
+        assert needed in params, (
+            f"pyzm Detector.detect_event lost the '{needed}' parameter that "
+            f"zm_detect.py passes by keyword."
+        )


### PR DESCRIPTION
Closes #36. Makes **green = mergeable** locally (releases are local), mirroring pyzmNg's gate.

## What
- **`make hooks`** installs a `pre-push` hook (`.githooks/pre-push`) that runs `make gate` and **blocks a red push**.
- **`make gate`** — perl `prove` + hook (`-m "not e2e"`) + tools. The per-push gate. Puts `PYZM_SRC` (default `~/fiddle/pyzmNg`) on `PYTHONPATH`.
- **`make release-gate`** — + real-pyzm e2e with `ZM_E2E_REQUIRE=1`.
- **`hook/tests/test_pyzm_contract.py`** — the highest-ROI test. Strips the unit stub, imports the **real** pyzm, and asserts the `DetectionResult.to_dict()` keys and `detect_event` signature ES actually consumes. Runs in-gate (PYTHONPATH set); skips if pyzm unimportable; **fails** under `ZM_E2E_REQUIRE=1`.
- **model-require fix** — `_discover_model()` extracted; `ZM_E2E_REQUIRE=1` now fails on "no usable YOLO model", not just a missing dir.

## Why
Audit: all 194 hook unit tests run against a hand-typed pyzm stub in `sys.modules`; the only real-pyzm tier skipped by default. A pyzm key rename (`confidences`→`confidence`) was a production `KeyError` with the whole suite green. The contract test closes that cross-repo hole.

## Verified
- `make gate` → perl 377 + hook 170 (168 unit + **2 contract now running in-gate**) + tools 95, all green.
- Contract test: skips without PYTHONPATH; passes with it; **fails** when pyzm's `to_dict` renames `confidences` (reproduced across repos, then reverted); fails under `ZM_E2E_REQUIRE=1` when pyzm is unimportable.
- e2e with `PYTHONPATH` → 26 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)