### PR TITLE
fix(hook): --fakeit + show_models: yes KeyError on model_names

### DIFF
--- a/hook/tests/test_main_handler.py
+++ b/hook/tests/test_main_handler.py
@@ -427,6 +427,21 @@ def test_fakeit_overrides_labels(harness, monkeypatch, tmp_path, capsys):
     assert FakeDetectionResult.last.data['labels'] == ['dog', 'person']
 
 
+def test_fakeit_with_show_models_does_not_crash(harness, monkeypatch, tmp_path, capsys):
+    """--fakeit + show_models: yes must not KeyError on model_names.
+
+    format_detection_output reads matched_data['model_names'][idx] when
+    show_models=='yes'; the fakeit override must supply model_names to match
+    the fake label count.
+    """
+    FakeDetector.result_data = {}          # detector finds nothing (KeyError path)
+    harness.cfg['show_models'] = 'yes'
+    _run(monkeypatch, tmp_path, ['-e', '55555', '-m', '7', '--fakeit', 'dog,person'])
+    out = capsys.readouterr().out
+    assert 'detected:' in out
+    assert 'dog' in out and 'person' in out
+
+
 # ---------------------------------------------------------------------------
 # ZM note update
 # ---------------------------------------------------------------------------

--- a/hook/zm_detect.py
+++ b/hook/zm_detect.py
@@ -167,6 +167,11 @@ def main_handler():
         matched_data['labels'] = fake_labels
         matched_data['boxes'] = [[50 + i * 100, 50, 150 + i * 100, 200] for i in range(len(fake_labels))]
         matched_data['confidences'] = [0.996] * len(fake_labels)
+        # Must stay index-aligned with labels: format_detection_output reads
+        # model_names[idx] when show_models=='yes'. Set (not setdefault) so a
+        # prior real detection's model_names can't leave a length mismatch.
+        matched_data['model_names'] = ['fakeit'] * len(fake_labels)
+        matched_data['detection_types'] = ['object'] * len(fake_labels)
         matched_data.setdefault('frame_id', 'snapshot')
         matched_data.setdefault('polygons', g.polygons)
         matched_data.setdefault('image_dimensions', {})


### PR DESCRIPTION
Closes #38. TDD red→green.

**Bug:** the `--fakeit` override rebuilt `matched_data` with labels/boxes/confidences but not `model_names`, and (unlike the normal path) never reassigned `matched_data = result.to_dict()`. `format_detection_output` reads `matched_data['model_names'][idx]` when `show_models: yes` → `KeyError` (or `IndexError` after a prior real detection).

**Fix:** set `model_names`/`detection_types` index-aligned to the fake labels.

**Test:** `test_fakeit_with_show_models_does_not_crash` — verified it `KeyError`s at `utils.py:71` before the fix, passes after. Full Tier-1 green (perl 377, hook 169, tools 95).

🤖 Generated with [Claude Code](https://claude.com/claude-code)