### PR TITLE
test: config-upgrade in-place write, secrets check, detector call signature

### DIFF
--- a/hook/tests/test_main_handler.py
+++ b/hook/tests/test_main_handler.py
@@ -112,6 +112,8 @@ class FakeDetector:
     result_image = None
     fail_when_gateway = False
     last_result = None
+    last_detect_event_call = None
+    last_detect_call = None
 
     def __init__(self, opts):
         self._opts = opts
@@ -131,9 +133,11 @@ class FakeDetector:
         return FakeDetector.last_result
 
     def detect(self, *a, **kw):
+        FakeDetector.last_detect_call = (a, kw)
         return self._run()
 
     def detect_event(self, *a, **kw):
+        FakeDetector.last_detect_event_call = (a, kw)
         return self._run()
 
 
@@ -212,6 +216,8 @@ def harness(monkeypatch, tmp_path):
     FakeDetector.result_image = None
     FakeDetector.fail_when_gateway = False
     FakeDetector.last_result = None
+    FakeDetector.last_detect_event_call = None
+    FakeDetector.last_detect_call = None
     FakeZMClient.last = None
     FakeZMClient.event_notes = ''
     LocalLogger.errors = []
@@ -425,6 +431,21 @@ def test_fakeit_overrides_labels(harness, monkeypatch, tmp_path, capsys):
     assert 'dog' in out and 'person' in out
     assert FakeDetectionResult.last is not None
     assert FakeDetectionResult.last.data['labels'] == ['dog', 'person']
+
+
+def test_detect_event_called_with_signature_zm_detect_expects(harness, monkeypatch, tmp_path):
+    """Guard against zm_detect.py drifting from pyzm's detect_event signature.
+
+    zm_detect.py calls detect_event(zm, int(stream), zones=..., stream_config=...).
+    The recording fake asserts that exact call shape so a wrong kwarg name or
+    dropped argument fails here (the real-pyzm side is locked by the contract
+    test)."""
+    _run(monkeypatch, tmp_path, ['-e', '55555', '-m', '7'])
+    a, kw = FakeDetector.last_detect_event_call
+    assert len(a) == 2                 # (zm_client, event_id) positional
+    assert a[1] == 55555               # event id passed positionally
+    assert 'zones' in kw
+    assert 'stream_config' in kw
 
 
 # ---------------------------------------------------------------------------

--- a/tools/tests/test_config_upgrade.py
+++ b/tools/tests/test_config_upgrade.py
@@ -112,3 +112,46 @@ class TestApplyRemovedKeys:
         removed = apply_removed_keys(user, ["hook.keep_frame_match_type", "hook.old_key"])
         assert sorted(removed) == ["hook.keep_frame_match_type", "hook.old_key"]
         assert list(user["hook"].keys()) == ["enabled"]
+
+
+# ── main() orchestration: the in-place write that touches user configs ──────
+
+class TestMainInPlace:
+    def _write(self, tmp_path, name, text):
+        p = tmp_path / name
+        p.write_text(text)
+        return str(p)
+
+    def _run_main(self, monkeypatch, argv):
+        import sys
+        monkeypatch.setattr(sys, "argv", ["config_upgrade_yaml.py"] + argv)
+        mod.main()
+
+    def test_dry_run_leaves_config_byte_identical(self, tmp_path, monkeypatch, capsys):
+        user = self._write(tmp_path, "user.yml", "a: 1\n")
+        example = self._write(tmp_path, "example.yml", "a: 1\nb: 2\n")
+        before = open(user).read()
+        self._run_main(monkeypatch, ["-c", user, "-e", example, "--dry-run"])
+        assert open(user).read() == before          # nothing written
+        assert "Dry run" in capsys.readouterr().out
+
+    def test_real_run_adds_missing_keys_preserving_order(self, tmp_path, monkeypatch):
+        # user has z first, then a -> order must be preserved, new key appended
+        user = self._write(tmp_path, "user.yml", "z: 10\na: 1\n")
+        example = self._write(tmp_path, "example.yml", "z: 10\na: 1\nb: 2\n")
+        self._run_main(monkeypatch, ["-c", user, "-e", example])
+        import yaml
+        text = open(user).read()
+        loaded = yaml.safe_load(text)
+        assert loaded == {"z": 10, "a": 1, "b": 2}   # new key merged in
+        # order preserved (sort_keys=False): z before a in the written file
+        assert text.index("z:") < text.index("a:")
+
+    def test_output_flag_does_not_touch_input(self, tmp_path, monkeypatch):
+        user = self._write(tmp_path, "user.yml", "a: 1\n")
+        example = self._write(tmp_path, "example.yml", "a: 1\nb: 2\n")
+        out = str(tmp_path / "out.yml")
+        before = open(user).read()
+        self._run_main(monkeypatch, ["-c", user, "-e", example, "-o", out])
+        assert open(user).read() == before          # input untouched
+        assert "b" in open(out).read()               # output has merged key

--- a/tools/tests/test_install_doctor.py
+++ b/tools/tests/test_install_doctor.py
@@ -186,3 +186,41 @@ class TestCheckModelFiles:
         warnings = check_model_files(models, str(tmp_path))
         assert len(warnings) == 1
         assert "object_config" in warnings[0]
+
+
+check_secrets_file = mod.check_secrets_file
+
+
+# ── check_secrets_file (readability diagnostic; security-relevant) ──────────
+
+class TestCheckSecretsFile:
+    def test_no_secrets_key_returns_none(self):
+        assert check_secrets_file({"general": {}}, "www-data") is None
+
+    def test_none_cfg_returns_none(self):
+        assert check_secrets_file(None, "www-data") is None
+
+    def test_missing_secrets_file_warns(self, tmp_path):
+        cfg = {"general": {"secrets": str(tmp_path / "nope.yml")}}
+        warn = check_secrets_file(cfg, "www-data")
+        assert warn is not None and "not found" in warn
+
+    def test_owner_readable_no_warning(self, tmp_path, monkeypatch):
+        sf = tmp_path / "secrets.yml"
+        sf.write_text("x"); sf.chmod(0o600)
+        # web user owns the file -> readable -> no warning
+        monkeypatch.setattr(mod, "uid_for_user", lambda u: os.getuid())
+        assert check_secrets_file({"general": {"secrets": str(sf)}}, "www-data") is None
+
+    def test_not_owner_and_not_world_readable_warns(self, tmp_path, monkeypatch):
+        sf = tmp_path / "secrets.yml"
+        sf.write_text("x"); sf.chmod(0o600)  # no other-read
+        monkeypatch.setattr(mod, "uid_for_user", lambda u: os.getuid() + 12345)
+        warn = check_secrets_file({"general": {"secrets": str(sf)}}, "www-data")
+        assert warn is not None and "may not be readable" in warn
+
+    def test_world_readable_no_warning_even_if_not_owner(self, tmp_path, monkeypatch):
+        sf = tmp_path / "secrets.yml"
+        sf.write_text("x"); sf.chmod(0o604)  # other-read set
+        monkeypatch.setattr(mod, "uid_for_user", lambda u: os.getuid() + 12345)
+        assert check_secrets_file({"general": {"secrets": str(sf)}}, "www-data") is None


### PR DESCRIPTION
refs #40. Robustness coverage for untested code where a green suite hid real breakage. Each teeth-proven.

- **`config_upgrade_yaml.main()`** (overwrites user configs in place) — `--dry-run` byte-identical, in-place merge preserving key order, `-o` leaves input untouched. Verified the dry-run test fails when the `--dry-run` guard is inverted.
- **`install_doctor.check_secrets_file`** (security-relevant, was untested) — owner-readable / world-readable / not-readable-warns / missing / no-key.
- **FakeDetector call signature** — records args; asserts `zm_detect.py` calls `detect_event(zm, id, zones=, stream_config=)`, so a call-site drift fails (real-pyzm side locked by the #37 contract test).

Tools 95→104, hook 168→169, perl unchanged. All green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)