### PR TITLE
test(perl): cover fork state-machine decisions (P3 of #42)

### DIFF
--- a/ZmEventNotification/HookProcessor.pm
+++ b/ZmEventNotification/HookProcessor.pm
@@ -256,6 +256,26 @@ sub _build_alarm_obj {
   };
 }
 
+# A hook that produced no detection text is a failure even if it exited 0.
+# Pure; used at both event-start and event-end in the fork state machine.
+# Locked by t/21.
+sub _effective_hook_result {
+  my ($exit_code, $res_txt) = @_;
+  return 1 if !defined($res_txt) || $res_txt eq '';
+  return $exit_code;
+}
+
+# Whether/why the event-end notification should be suppressed. Returns
+# 'start_failed' (event_end_notify_if_start_success is on and the start hook
+# failed), 'rules' (rules checks disallow it), or '' (send it). Pure; locked
+# by t/21.
+sub _end_notify_skip_reason {
+  my ($notify_if_start_success, $start_hook_result, $rules_allowed) = @_;
+  return 'start_failed' if $notify_if_start_success && $start_hook_result != 0;
+  return 'rules' if !$rules_allowed;
+  return '';
+}
+
 sub _run_api_push {
   my ($temp_alarm_obj, $eid, $mid, $event_type, $hookResult) = @_;
   return unless $push_config{enabled} && $push_config{script};
@@ -342,7 +362,7 @@ sub processNewAlarmsInFork {
 
           chomp($res);
           my ( $resTxt, $resJsonString ) = parseDetectResults($res);
-          $hookResult = 1 if !$resTxt;
+          $hookResult = _effective_hook_result($hookResult, $resTxt);
           $startHookResult = $hookResult;
 
           main::Debug(1, "hook start returned with text:$resTxt json:$resJsonString exit:$hookResult");
@@ -468,7 +488,7 @@ sub processNewAlarmsInFork {
 
           chomp($res);
           my ( $resTxt, $resJsonString ) = parseDetectResults($res);
-          $hookResult = 1 if (!$resTxt);
+          $hookResult = _effective_hook_result($hookResult, $resTxt);
 
           $alarm->{End}->{State} = 'ready';
           main::Debug(1, "hook end returned with text:$resTxt  json:$resJsonString exit:$hookResult");
@@ -534,11 +554,13 @@ sub processNewAlarmsInFork {
 
       my ( $rulesAllowed, $rulesObject ) = isAllowedInRules($alarm);
 
-      if ( $hooks_config{event_end_notify_if_start_success} && ($startHookResult != 0) ) {
+      my $end_skip = _end_notify_skip_reason(
+        $hooks_config{event_end_notify_if_start_success}, $startHookResult, $rulesAllowed);
+      if ( $end_skip eq 'start_failed' ) {
         main::Info(
           'Not sending event end alarm, as we did not send a start alarm for this, or start hook processing failed'
         );
-      } elsif ( !$rulesAllowed ) {
+      } elsif ( $end_skip eq 'rules' ) {
         main::Debug(1, 'rules: Not processing end notifications as rules checks failed for start notification');
       } else {
         my $temp_alarm_obj = _build_alarm_obj(

--- a/t/21-fork-decisions.t
+++ b/t/21-fork-decisions.t
@@ -1,0 +1,51 @@
+#!/usr/bin/env perl
+# Decision logic extracted from processNewAlarmsInFork (the fork state machine).
+# The full loop shells out to hooks, reads SHM, and sleeps -- not a good direct
+# test target -- but its two most consequential decisions are pure and are
+# locked here:
+#   - _effective_hook_result: a hook that produced no detection text is a
+#     failure even if it exited 0 ($hookResult = 1 if !$resTxt), used at both
+#     event-start and event-end.
+#   - _end_notify_skip_reason: when event_end_notify_if_start_success is on and
+#     the start hook failed, the end notification must be suppressed (line 537).
+use strict;
+use warnings;
+use FindBin;
+use lib "$FindBin::Bin/../";
+use lib "$FindBin::Bin/lib";
+
+use Test::More;
+require StubZM;
+use ZmEventNotification::HookProcessor;
+
+my $effective   = \&ZmEventNotification::HookProcessor::_effective_hook_result;
+my $skip_reason = \&ZmEventNotification::HookProcessor::_end_notify_skip_reason;
+
+# ===== _effective_hook_result($exit_code, $resTxt) =====
+subtest '_effective_hook_result: no detection text => failure (1)' => sub {
+  is($effective->(0, ''),    1, 'exit 0 but empty text -> fail');
+  is($effective->(0, undef), 1, 'exit 0 but undef text -> fail');
+};
+subtest '_effective_hook_result: detection text present => keep exit code' => sub {
+  is($effective->(0, 'detected:person'), 0, 'exit 0 with text -> success');
+  is($effective->(1, 'detected:person'), 1, 'nonzero exit preserved even with text');
+};
+
+# ===== _end_notify_skip_reason($notify_if_start_success, $startHookResult, $rulesAllowed) =====
+subtest '_end_notify_skip_reason: suppressed when start hook failed' => sub {
+  is($skip_reason->(1, 1, 1), 'start_failed',
+     'notify_if_start_success on + start failed -> suppress');
+  is($skip_reason->(1, 2, 1), 'start_failed', 'any nonzero start result suppresses');
+};
+subtest '_end_notify_skip_reason: not suppressed when start succeeded' => sub {
+  is($skip_reason->(1, 0, 1), '', 'start succeeded -> send');
+};
+subtest '_end_notify_skip_reason: gate off => start result ignored' => sub {
+  is($skip_reason->(0, 1, 1), '', 'gate off -> send despite start failure');
+};
+subtest '_end_notify_skip_reason: rules failure suppresses (when not start-gated)' => sub {
+  is($skip_reason->(0, 0, 0), 'rules', 'rules disallowed -> suppress');
+  is($skip_reason->(1, 0, 0), 'rules', 'start ok but rules disallowed -> suppress');
+};
+
+done_testing();


### PR DESCRIPTION
Completes the **P3** portion of #42.

`processNewAlarmsInFork`'s 300-line loop shells out to hooks, reads SHM, and `sleep(2)`s per iteration — a poor direct test target (driving it whole would be slow/flaky). Instead, extracted its two most consequential decisions into pure, tested functions and routed the fork code through them:

- **`_effective_hook_result(exit, resTxt)`** — a hook that produced no detection text is a failure even if it exited 0 (was inline `$hookResult = 1 if !$resTxt` at both event-start and event-end; now DRY across both).
- **`_end_notify_skip_reason(notify_if_start_success, startHookResult, rulesAllowed)`** — suppress the event-end notification when the start hook failed (the line-537 `startHookResult != 0` gate) or rules disallow it.

Equivalence-preserving (`perl -c` OK; every branch/message preserved). `t/21` locks both; **verified the gate test fails when `!= 0` is inverted**. Perl suite 396 → 402.

Note: the full loop's SHM/sleep-driven flow (start→ready→done→end) remains untested as-is; testing it well needs the `sleep`/SHM seam broken out, tracked as a possible future refactor. This PR locks the two decisions the audit named as most dangerous.

🤖 Generated with [Claude Code](https://claude.com/claude-code)